### PR TITLE
Fixing an issue with reset code check

### DIFF
--- a/components/ResetPassword.php
+++ b/components/ResetPassword.php
@@ -95,7 +95,7 @@ class ResetPassword extends BaseComponent
 
         $customer = Customers_model::whereResetCode($code = post('code'))->first();
 
-        if (!$customer OR $customer->completeResetPassword($code, post('password')))
+        if (!$customer OR !$customer->completeResetPassword($code, post('password')))
             throw new ApplicationException(lang('igniter.user::default.reset.alert_reset_failed'));
 
         flash()->success(lang('igniter.user::default.reset.alert_reset_success'));


### PR DESCRIPTION
This small change fixes an issue with improper logic in check if reset code is valid, causing user reset form to not allow for password resetting even if the code is valid and not expired.