### PR TITLE
Update validation on login and register to trim whitespace

### DIFF
--- a/components/Account.php
+++ b/components/Account.php
@@ -169,7 +169,8 @@ class Account extends \System\Classes\BaseComponent
                 ['remember', 'lang:igniter.user::default.login.label_remember', 'integer'],
             ];
 
-            $this->validate(post(), $namedRules);
+            $data = array_map('trim', post());
+            $this->validate($data, $namedRules);
 
             $remember = (bool)post('remember');
             $credentials = [
@@ -201,7 +202,7 @@ class Account extends \System\Classes\BaseComponent
             if (!(bool)setting('allow_registration', TRUE))
                 throw new ApplicationException(lang('igniter.user::default.login.alert_registration_disabled'));
 
-            $data = post();
+            $data = array_map('trim', post());
 
             $rules = [
                 ['first_name', 'lang:igniter.user::default.settings.label_first_name', 'required|between:1,48'],


### PR DESCRIPTION
Trim the whitespace from the input values before running validation rules to avoid issues with autofill on mobile devices for email addresses.