### PR TITLE
fix: CustomerRequest unique email ignore on API update

### DIFF
--- a/src/Http/Requests/CustomerRequest.php
+++ b/src/Http/Requests/CustomerRequest.php
@@ -10,6 +10,11 @@ use Override;
 
 class CustomerRequest extends FormRequest
 {
+    protected function getRecordId(): int|string|null
+    {
+        return $this->route('customer') ?? parent::getRecordId();
+    }
+
     #[Override]
     public function attributes(): array
     {

--- a/src/Http/Requests/CustomerRequest.php
+++ b/src/Http/Requests/CustomerRequest.php
@@ -10,6 +10,7 @@ use Override;
 
 class CustomerRequest extends FormRequest
 {
+    #[Override]
     protected function getRecordId(): int|string|null
     {
         return $this->route('customer') ?? parent::getRecordId();

--- a/tests/Http/Requests/CustomerRequestTest.php
+++ b/tests/Http/Requests/CustomerRequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Igniter\User\Tests\Http\Requests;
 
 use Igniter\User\Http\Requests\CustomerRequest;
+use Illuminate\Routing\Route;
 
 it('returns correct attribute labels for customer', function(): void {
     $attributes = (new CustomerRequest)->attributes();
@@ -51,6 +52,49 @@ it('validates rules correctly for customer', function(): void {
         ->and($rules['addresses.*.city'])->toBe(['nullable', 'string', 'min:2', 'max:255'])
         ->and($rules['addresses.*.state'])->toBe(['nullable', 'string', 'max:255'])
         ->and($rules['addresses.*.postcode'])->toBe(['nullable', 'string']);
+});
+
+it('returns customer route parameter from getRecordId', function(): void {
+    $customerRequest = new CustomerRequest;
+
+    $route = new Route(['PUT'], '/api/customers/{customer}', []);
+    $route->bind($customerRequest);
+    $route->setParameter('customer', 42);
+
+    $customerRequest->setRouteResolver(fn(): Route => $route);
+
+    $recordId = $customerRequest->getRecordId();
+
+    expect($recordId)->toBe(42);
+});
+
+it('falls back to parent getRecordId when customer route parameter is absent', function(): void {
+    $customerRequest = new CustomerRequest;
+
+    $route = new Route(['PUT'], '/admin/customers/{slug}', []);
+    $route->bind($customerRequest);
+    $route->setParameter('slug', 'igniter/customers/5');
+
+    $customerRequest->setRouteResolver(fn(): Route => $route);
+
+    $recordId = $customerRequest->getRecordId();
+
+    expect($recordId)->toBe('5');
+});
+
+it('unique email rule ignores the customer being updated', function(): void {
+    $customerRequest = new CustomerRequest;
+    $customerRequest->setMethod('patch');
+
+    $route = new Route(['PATCH'], '/api/customers/{customer}', []);
+    $route->bind($customerRequest);
+    $route->setParameter('customer', 7);
+
+    $customerRequest->setRouteResolver(fn(): Route => $route);
+
+    $rules = $customerRequest->rules();
+
+    expect($rules['email'][3]->__toString())->toBe('unique:customers,NULL,7,customer_id');
 });
 
 it('has correct validation rules when request is patch', function(): void {

--- a/tests/Http/Requests/CustomerRequestTest.php
+++ b/tests/Http/Requests/CustomerRequestTest.php
@@ -55,7 +55,13 @@ it('validates rules correctly for customer', function(): void {
 });
 
 it('returns customer route parameter from getRecordId', function(): void {
-    $customerRequest = new CustomerRequest;
+    $customerRequest = new class extends CustomerRequest
+    {
+        public function exposeGetRecordId(): int|string|null
+        {
+            return $this->getRecordId();
+        }
+    };
 
     $route = new Route(['PUT'], '/api/customers/{customer}', []);
     $route->bind($customerRequest);
@@ -63,13 +69,19 @@ it('returns customer route parameter from getRecordId', function(): void {
 
     $customerRequest->setRouteResolver(fn(): Route => $route);
 
-    $recordId = $customerRequest->getRecordId();
+    $recordId = $customerRequest->exposeGetRecordId();
 
     expect($recordId)->toBe(42);
 });
 
 it('falls back to parent getRecordId when customer route parameter is absent', function(): void {
-    $customerRequest = new CustomerRequest;
+    $customerRequest = new class extends CustomerRequest
+    {
+        public function exposeGetRecordId(): int|string|null
+        {
+            return $this->getRecordId();
+        }
+    };
 
     $route = new Route(['PUT'], '/admin/customers/{slug}', []);
     $route->bind($customerRequest);
@@ -77,7 +89,7 @@ it('falls back to parent getRecordId when customer route parameter is absent', f
 
     $customerRequest->setRouteResolver(fn(): Route => $route);
 
-    $recordId = $customerRequest->getRecordId();
+    $recordId = $customerRequest->exposeGetRecordId();
 
     expect($recordId)->toBe('5');
 });


### PR DESCRIPTION
## Summary

- **Bug**: A `PATCH /api/customers/{id}` or `PUT /api/customers/{id}` request that resends the customer's own (unchanged) email incorrectly fails with HTTP 422 `"Email has already been taken"`.
- **Root cause**: `CustomerRequest` inherits `getRecordId()` from the parent `FormRequest`, which reads `$this->route('slug')`. The API resource route binds the customer model as `{customer}`, so `route('slug')` returns `null`, causing the unique rule to call `->ignore(null, 'customer_id')` — which ignores no record.
- **Fix**: Override `getRecordId()` in `CustomerRequest` to prefer the `{customer}` route parameter (API routes) and fall back to the parent's slug-based resolution (admin routes).

## Reproduction

```bash
# 1. Fetch an existing customer
GET /api/customers/1
# Note the email, e.g. "jane@example.com"

# 2. Send a partial update resending the same email
PATCH /api/customers/1
Content-Type: application/json
Authorization: Bearer <token>

{ "email": "jane@example.com" }

# Result (before fix): 422 Unprocessable Entity
# { "errors": { "email": ["The email has already been taken."] } }

# Result (after fix): 200 OK
```

## The Fix

Added a `getRecordId()` override in `CustomerRequest`:

```php
protected function getRecordId(): int|string|null
{
    return $this->route('customer') ?? parent::getRecordId();
}
```

This resolves the correct record ID from the `{customer}` route parameter used by API resource routes, while preserving the existing `{slug}` fallback for admin routes.

## Test Plan

Three new tests were added to `tests/Http/Requests/CustomerRequestTest.php`:

1. **`it('returns customer route parameter from getRecordId')`** — Verifies that `getRecordId()` returns the value of the `{customer}` route parameter when present.
2. **`it('falls back to parent getRecordId when customer route parameter is absent')`** — Verifies that when only a `{slug}` parameter is present (admin routes), the parent logic correctly extracts the numeric ID from the slug string.
3. **`it('unique email rule ignores the customer being updated')`** — Verifies that on a PATCH request the unique rule string contains the correct customer ID as the ignore value, confirming end-to-end that the bug is fixed.

To run these tests locally:

```bash
composer test -- --filter CustomerRequest
```

> Note: Tests use testbench and require a configured database to run.