### PR TITLE
fix: use single-quoted SQL string literal in Customer::getDropdownOptions for PostgreSQL

### DIFF
--- a/src/Models/Customer.php
+++ b/src/Models/Customer.php
@@ -131,7 +131,7 @@ class Customer extends AuthUserModel
     {
         return static::query()
             ->whereIsEnabled()
-            ->selectRaw('customer_id, concat(first_name, " ", last_name) as name')
+            ->selectRaw("customer_id, concat(first_name, ' ', last_name) as name")
             ->dropdown('name');
     }
 


### PR DESCRIPTION
## Problem

`Customer::getDropdownOptions()` fails on **PostgreSQL** with:

```
ERROR: column " " does not exist
```

The raw SQL contains a double-quoted space character:

```php
->selectRaw('customer_id, concat(first_name, " ", last_name) as name')
```

This produces the SQL: `concat(first_name, " ", last_name)`. In PostgreSQL, double quotes denote **identifiers** (column/table names), not string literals. So `" "` is interpreted as a column named ` ` (a space), which doesn't exist.

MySQL is lenient and accepts double-quoted strings; PostgreSQL is not.

## Fix

Use single-quoted string literals inside the SQL expression (using PHP double quotes for the outer string):

```php
// Before
->selectRaw('customer_id, concat(first_name, " ", last_name) as name')

// After
->selectRaw("customer_id, concat(first_name, ' ', last_name) as name")
```

This is valid SQL in both MySQL and PostgreSQL.